### PR TITLE
fix(fe): background on all browser themes to be dark

### DIFF
--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -9,11 +9,8 @@
 
 html,
 body {
-  @apply bg-white dark:bg-gray-950;
-
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-  }
+  @apply bg-gray-950;
+  color-scheme: dark;
 }
 
 .logo-text {


### PR DESCRIPTION
Previously, when your browser's theme to be on light mode, the code in frontend/app/app.css would make the background color light, but we do not have any other styling in the app to be this way.

For now, we won't worry about theming, we will keep the entire theme to be dark.