### PR TITLE
impr(fe): allow dirty-code backtests

### DIFF
--- a/frontend/app/routes/strategy/backtest.tsx
+++ b/frontend/app/routes/strategy/backtest.tsx
@@ -66,6 +66,8 @@ type StrategyEquityChartProps = {
   candles: EquityCandle[];
   onSave: () => void;
   isSaving: boolean;
+  isSaveDisabled: boolean;
+  saveDisabledReason?: string;
   isViewingSaved: boolean;
   showPlaceholder: boolean;
   animatePlaceholder: boolean;
@@ -98,12 +100,13 @@ export default function StrategyBacktest() {
     strategy,
     entrypoint,
     addToast,
-    isDirty,
     isSaving: isWorkspaceSaving,
     latestBacktestData,
     setLatestBacktestData,
-    latestBacktestStrategyVersion,
     setLatestBacktestStrategyVersion,
+    latestBacktestStrategyCode,
+    setLatestBacktestStrategyCode,
+    savedEntrypointContent,
     lastBacktestParamValues,
     setLastBacktestParamValues,
     refreshSavedBacktestRuns,
@@ -114,6 +117,7 @@ export default function StrategyBacktest() {
   const [isRunningBacktest, setIsRunningBacktest] = useState(false);
   const [isSavingBacktest, setIsSavingBacktest] = useState(false);
   const backtestData = latestBacktestData;
+  const currentEntrypointContent = typeof entrypoint?.content === "string" ? entrypoint.content : null;
   const lastRunParameters = useMemo(
     () =>
       DEFAULT_PARAMETERS.map((param) => ({
@@ -127,10 +131,6 @@ export default function StrategyBacktest() {
     if (isRunningBacktest) return;
     if (isWorkspaceSaving) {
       addToast("Please wait for your strategy changes to finish saving before running a backtest.", "info");
-      return;
-    }
-    if (isDirty) {
-      addToast("Save a new version of your strategy before running a backtest.", "warning");
       return;
     }
 
@@ -147,7 +147,10 @@ export default function StrategyBacktest() {
     setActiveBacktestSource("live");
     setActiveSavedRunId(null);
     setLatestBacktestData(null);
-    setLatestBacktestStrategyVersion(strategy.current_version ?? null);
+    setLatestBacktestStrategyCode(strategyCode);
+    setLatestBacktestStrategyVersion(
+      savedEntrypointContent !== null && strategyCode === savedEntrypointContent ? strategy.current_version ?? null : null
+    );
     addToast(`Queued backtest for ${values.name ?? "strategy"}`, "info");
     setLastBacktestParamValues(values);
 
@@ -164,6 +167,7 @@ export default function StrategyBacktest() {
     } catch {
       setLatestBacktestData(null);
       setLatestBacktestStrategyVersion(null);
+      setLatestBacktestStrategyCode(null);
       addToast("Backtest failed", "warning");
     } finally {
       setIsRunningBacktest(false);
@@ -179,6 +183,25 @@ export default function StrategyBacktest() {
     }
     if (activeBacktestSource === "saved") {
       addToast("This is an existing saved run. Run a new backtest to save again.", "info");
+      return;
+    }
+    if (!latestBacktestStrategyCode) {
+      addToast("Code snapshot missing for this run. Please run the backtest again.", "warning");
+      return;
+    }
+    if (!currentEntrypointContent || latestBacktestStrategyCode !== currentEntrypointContent) {
+      addToast("Save blocked: strategy code has changed since this backtest ran. Re-run backtest to save results.", "warning");
+      return;
+    }
+    if (!savedEntrypointContent || latestBacktestStrategyCode !== savedEntrypointContent) {
+      addToast(
+        "Save blocked: save a strategy version with the exact code used for this backtest before saving results.",
+        "warning"
+      );
+      return;
+    }
+    if (strategy.current_version === null || strategy.current_version === undefined) {
+      addToast("Save blocked: strategy version is unavailable. Save strategy code and try again.", "warning");
       return;
     }
 
@@ -213,9 +236,7 @@ export default function StrategyBacktest() {
         },
       };
 
-      if (latestBacktestStrategyVersion !== null && latestBacktestStrategyVersion !== undefined) {
-        finalizePayload.strategy_version = latestBacktestStrategyVersion;
-      }
+      finalizePayload.strategy_version = strategy.current_version;
 
       await finalizeBacktestRun(strategy.id, finalizePayload);
 
@@ -233,6 +254,35 @@ export default function StrategyBacktest() {
 
   const showPlaceholder = !backtestData || isRunningBacktest;
   const animatePlaceholder = isRunningBacktest;
+  const saveDisabledReason = useMemo(() => {
+    if (!backtestData) {
+      return "Run a backtest before saving.";
+    }
+    if (activeBacktestSource === "saved") {
+      return "This run is already saved.";
+    }
+    if (!latestBacktestStrategyCode) {
+      return "Run a new backtest to capture the strategy code snapshot.";
+    }
+    if (!currentEntrypointContent || latestBacktestStrategyCode !== currentEntrypointContent) {
+      return "Strategy code changed after this run. Re-run backtest before saving results.";
+    }
+    if (!savedEntrypointContent || latestBacktestStrategyCode !== savedEntrypointContent) {
+      return "Save a strategy version with this exact code before saving results.";
+    }
+    if (strategy.current_version === null || strategy.current_version === undefined) {
+      return "Save a strategy version before saving results.";
+    }
+    return undefined;
+  }, [
+    activeBacktestSource,
+    backtestData,
+    currentEntrypointContent,
+    latestBacktestStrategyCode,
+    savedEntrypointContent,
+    strategy.current_version,
+  ]);
+  const isSaveDisabled = showPlaceholder || isSavingBacktest || !!saveDisabledReason;
   const skeletonBaseColor = "#111a26";
   const skeletonHighlightColor = animatePlaceholder ? "#1d2a3f" : skeletonBaseColor;
 
@@ -258,10 +308,8 @@ export default function StrategyBacktest() {
               strategyName={strategy.name}
               parameters={lastRunParameters}
               isRunning={isRunningBacktest}
-              isDisabled={isRunningBacktest || isDirty || isWorkspaceSaving}
-              disabledReason={
-                isDirty ? "Save a new version before running." : isWorkspaceSaving ? "Saving changes…" : undefined
-              }
+              isDisabled={isRunningBacktest || isWorkspaceSaving}
+              disabledReason={isWorkspaceSaving ? "Saving changes…" : undefined}
               onRun={handleRunBacktest}
             />
             <BacktestMetrics metrics={metrics} showPlaceholder={showPlaceholder} animatePlaceholder={animatePlaceholder} />
@@ -274,6 +322,8 @@ export default function StrategyBacktest() {
               candles={candles}
               onSave={handleSaveResults}
               isSaving={isSavingBacktest}
+              isSaveDisabled={isSaveDisabled}
+              saveDisabledReason={saveDisabledReason}
               isViewingSaved={activeBacktestSource === "saved"}
               showPlaceholder={showPlaceholder}
               animatePlaceholder={animatePlaceholder}
@@ -405,10 +455,22 @@ function BacktestMetrics({ metrics, showPlaceholder, animatePlaceholder }: Backt
   );
 }
 
-function StrategyEquityChart({ strategyName, stats, candles, onSave, isSaving, isViewingSaved, showPlaceholder, animatePlaceholder }: StrategyEquityChartProps) {
+function StrategyEquityChart({
+  strategyName,
+  stats,
+  candles,
+  onSave,
+  isSaving,
+  isSaveDisabled,
+  saveDisabledReason,
+  isViewingSaved,
+  showPlaceholder,
+  animatePlaceholder,
+}: StrategyEquityChartProps) {
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
   const [benchmarkEnabled, setBenchmarkEnabled] = useState(true);
   const [selectedBenchmark, setSelectedBenchmark] = useState("sp500");
+  const saveHelperTextId = "save-results-helper-text";
 
   useEffect(() => {
     if (showPlaceholder || !chartContainerRef.current) {
@@ -468,18 +530,26 @@ function StrategyEquityChart({ strategyName, stats, candles, onSave, isSaving, i
           <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Strategy Equity</p>
           <h2 className="text-xl font-semibold text-white">{strategyName ?? "Active strategy"}</h2>
         </div>
-        <button
-          type="button"
-          onClick={onSave}
-          disabled={showPlaceholder || isSaving || isViewingSaved}
-          className={`rounded-full px-4 py-2 text-sm font-semibold text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-500 ${
-            showPlaceholder || isSaving || isViewingSaved
-              ? "cursor-not-allowed bg-slate-700/70 text-slate-300"
-              : "bg-fuchsia-500 hover:bg-fuchsia-400"
-          }`}
-        >
-          {isViewingSaved ? "Saved Run" : isSaving ? "Saving…" : "Save to Results"}
-        </button>
+        <div className="flex flex-col items-end gap-2">
+          <button
+            type="button"
+            onClick={onSave}
+            disabled={isSaveDisabled}
+            aria-describedby={isSaveDisabled && saveDisabledReason ? saveHelperTextId : undefined}
+            className={`rounded-full px-4 py-2 text-sm font-semibold text-white transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-fuchsia-500 ${
+              isSaveDisabled
+                ? "cursor-not-allowed bg-slate-700/70 text-slate-300"
+                : "bg-fuchsia-500 hover:bg-fuchsia-400"
+            }`}
+          >
+            {isViewingSaved ? "Saved Run" : isSaving ? "Saving…" : "Save to Results"}
+          </button>
+          {isSaveDisabled && saveDisabledReason ? (
+            <p id={saveHelperTextId} className="max-w-xs text-right text-sm text-slate-400">
+              {saveDisabledReason}
+            </p>
+          ) : null}
+        </div>
 	      </header>
 
       <dl className="mt-6 grid gap-4 md:grid-cols-3 lg:grid-cols-5">

--- a/frontend/app/routes/strategy/layout.tsx
+++ b/frontend/app/routes/strategy/layout.tsx
@@ -34,6 +34,9 @@ export type StrategyWorkspaceContext = {
   setLatestBacktestData: (data: BacktestResponse | null) => void;
   latestBacktestStrategyVersion: number | string | null;
   setLatestBacktestStrategyVersion: (version: number | string | null) => void;
+  latestBacktestStrategyCode: string | null;
+  setLatestBacktestStrategyCode: (code: string | null) => void;
+  savedEntrypointContent: string | null;
   lastBacktestParamValues: Record<string, string>;
   setLastBacktestParamValues: (values: Record<string, string>) => void;
   activeBacktestSource: "live" | "saved" | null;
@@ -59,6 +62,11 @@ function cloneFiles(items: StrategyFile[]): StrategyFile[] {
   return items.map((file) => ({ ...file }));
 }
 
+function getEntrypointContent(items: StrategyFile[]): string | null {
+  const entrypoint = items.find((file) => file.isEntrypoint);
+  return typeof entrypoint?.content === "string" ? entrypoint.content : null;
+}
+
 export default function StrategyLayout() {
   const { strategyId = "1" } = useParams<{ strategyId?: string }>();
   const navigate = useNavigate();
@@ -80,6 +88,8 @@ export default function StrategyLayout() {
   const [loadedFilePaths, setLoadedFilePaths] = useState<string[]>([]);
   const [latestBacktestData, setLatestBacktestData] = useState<BacktestResponse | null>(null);
   const [latestBacktestStrategyVersion, setLatestBacktestStrategyVersion] = useState<number | string | null>(null);
+  const [latestBacktestStrategyCode, setLatestBacktestStrategyCode] = useState<string | null>(null);
+  const [savedEntrypointContent, setSavedEntrypointContent] = useState<string | null>(null);
   const [lastBacktestParamValues, setLastBacktestParamValues] = useState<Record<string, string>>({});
   const [activeBacktestSource, setActiveBacktestSource] = useState<"live" | "saved" | null>(null);
   const [activeSavedRunId, setActiveSavedRunId] = useState<string | null>(null);
@@ -132,6 +142,8 @@ export default function StrategyLayout() {
         }
         setLatestBacktestData(null);
         setLatestBacktestStrategyVersion(null);
+        setLatestBacktestStrategyCode(null);
+        setSavedEntrypointContent(getEntrypointContent(payload.files));
         setLastBacktestParamValues({});
         setActiveBacktestSource(null);
         setActiveSavedRunId(null);
@@ -229,7 +241,16 @@ export default function StrategyLayout() {
         setFiles((prev) => prev.map((f) => (f.path === selectedFilePath ? { ...f, content: content ?? "" } : f)));
         initialFilesRef.current = initialFilesRef.current.some((f) => f.path === selectedFilePath)
           ? initialFilesRef.current.map((f) => (f.path === selectedFilePath ? { ...f, content: content ?? "" } : f))
-          : [...initialFilesRef.current, { path: selectedFilePath, content: content ?? "", language: file?.language ?? "plaintext" }];
+          : [
+              ...initialFilesRef.current,
+              {
+                path: selectedFilePath,
+                content: content ?? "",
+                language: file?.language ?? "plaintext",
+                isEntrypoint: file?.isEntrypoint,
+              },
+            ];
+        setSavedEntrypointContent(getEntrypointContent(initialFilesRef.current));
         setLoadedFilePaths((prev) => (prev.includes(selectedFilePath) ? prev : [...prev, selectedFilePath]));
       })
       .catch((error) => {
@@ -272,6 +293,7 @@ export default function StrategyLayout() {
     try {
       const result = await uploadStrategyArtifacts(strategy.id, changedFiles);
       initialFilesRef.current = cloneFiles(files);
+      setSavedEntrypointContent(getEntrypointContent(initialFilesRef.current));
       setIsDirty(false);
       setAutosaveMessage("All changes saved");
       setStrategy((prev) =>
@@ -388,6 +410,9 @@ export default function StrategyLayout() {
     setLatestBacktestData,
     latestBacktestStrategyVersion,
     setLatestBacktestStrategyVersion,
+    latestBacktestStrategyCode,
+    setLatestBacktestStrategyCode,
+    savedEntrypointContent,
     lastBacktestParamValues,
     setLastBacktestParamValues,
     activeBacktestSource,

--- a/frontend/app/routes/strategy/results.tsx
+++ b/frontend/app/routes/strategy/results.tsx
@@ -45,6 +45,7 @@ export default function StrategyResults() {
     addToast,
     setLatestBacktestData,
     setLatestBacktestStrategyVersion,
+    setLatestBacktestStrategyCode,
     setLastBacktestParamValues,
     setActiveBacktestSource,
     setActiveSavedRunId,
@@ -71,6 +72,7 @@ export default function StrategyResults() {
 
       setLatestBacktestData(backtest);
       setLatestBacktestStrategyVersion(resp.item.strategy_version ?? null);
+      setLatestBacktestStrategyCode(null);
       setActiveBacktestSource("saved");
       setActiveSavedRunId(run.run_id);
 


### PR DESCRIPTION
- Allow "dirty" code in strategies to be able to run backtests
- Don't allow users to save backtests unless code is saved, and saved code is the same as the one the backtest was ran on