### PR TITLE
feat: async job polling endpoints

### DIFF
--- a/frontend/app/api/backtest.ts
+++ b/frontend/app/api/backtest.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { backtesterApiOrigin, isProd } from "./runtime";
 
+
 const BACKTESTER_ENDPOINT = "/api/v1/backtest";
 const backtesterApiBaseUrl = isProd
   ? `${backtesterApiOrigin}${BACKTESTER_ENDPOINT}`
@@ -75,7 +76,24 @@ export type BacktestRequest = {
   initial_capital: number;
 };
 
-export const runBacktest = async (payload: BacktestRequest): Promise<BacktestResponse> => {
-  const response = await backtesterApi.post<BacktestResponse>("", payload);
+export type JobStatus = "PENDING" | "RUNNING" | "COMPLETED" | "FAILED" | "CANCELLED";
+
+export type JobRecord = {
+  job_id: string;
+  status: JobStatus;
+  submitted_at: string;
+  started_at?: string;
+  completed_at?: string;
+  result?: BacktestResponse;
+  error?: string;
+};
+
+export const submitBacktest = async (payload: BacktestRequest): Promise<string> => {
+  const response = await backtesterApi.post<{ job_id: string }>("", payload);
+  return response.data.job_id;
+};
+
+export const getBacktestJob = async (jobId: string): Promise<JobRecord> => {
+  const response = await backtesterApi.get<JobRecord>(`/${jobId}`);
   return response.data;
 };

--- a/frontend/app/routes/strategy/backtest.tsx
+++ b/frontend/app/routes/strategy/backtest.tsx
@@ -10,7 +10,8 @@ import {
 import Skeleton, { SkeletonTheme } from "react-loading-skeleton";
 import "react-loading-skeleton/dist/skeleton.css";
 import {
-  runBacktest,
+  submitBacktest,
+  getBacktestJob,
   type BacktestCandle,
   type BacktestOrder,
   type BacktestResponse,
@@ -117,6 +118,13 @@ export default function StrategyBacktest() {
   } = useStrategyWorkspace();
   const [isRunningBacktest, setIsRunningBacktest] = useState(false);
   const [isSavingBacktest, setIsSavingBacktest] = useState(false);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (pollIntervalRef.current !== null) clearInterval(pollIntervalRef.current);
+    };
+  }, []);
   const backtestData = latestBacktestData;
   const currentEntrypointContent = typeof entrypoint?.content === "string" ? entrypoint.content : null;
   const lastRunParameters = useMemo(
@@ -156,22 +164,54 @@ export default function StrategyBacktest() {
     setLastBacktestParamValues(values);
 
     try {
-      const response = await runBacktest({
+      const jobId = await submitBacktest({
         strategy_code: strategyCode,
         start_date: values.startDate,
         end_date: values.endDate,
         initial_capital: initialCapital,
       });
 
-      setLatestBacktestData(response);
-      addToast("Backtest finished", "success");
-    } catch {
+      const POLL_INTERVAL_MS = 2000;
+      pollIntervalRef.current = setInterval(async () => {
+        try {
+          const job = await getBacktestJob(jobId);
+
+          if (job.status === "COMPLETED") {
+            clearInterval(pollIntervalRef.current!);
+            pollIntervalRef.current = null;
+            setLatestBacktestData(job.result!);
+            setIsRunningBacktest(false);
+            addToast("Backtest finished", "success");
+            console.log("[Backtest] Completed:", job);
+          } else if (job.status === "FAILED" || job.status === "CANCELLED") {
+            clearInterval(pollIntervalRef.current!);
+            pollIntervalRef.current = null;
+            setLatestBacktestData(null);
+            setLatestBacktestStrategyVersion(null);
+            setLatestBacktestStrategyCode(null);
+            setIsRunningBacktest(false);
+            addToast("Backtest failed", "warning");
+            console.error("[Backtest] Job failed:", job.error ?? "(no error details)", job);
+          }
+          // PENDING / RUNNING → keep polling
+        } catch (pollError) {
+          clearInterval(pollIntervalRef.current!);
+          pollIntervalRef.current = null;
+          setLatestBacktestData(null);
+          setLatestBacktestStrategyVersion(null);
+          setLatestBacktestStrategyCode(null);
+          setIsRunningBacktest(false);
+          addToast("Backtest failed", "warning");
+          console.error("[Backtest] Polling error:", pollError);
+        }
+      }, POLL_INTERVAL_MS);
+    } catch (submitError) {
       setLatestBacktestData(null);
       setLatestBacktestStrategyVersion(null);
       setLatestBacktestStrategyCode(null);
-      addToast("Backtest failed", "warning");
-    } finally {
       setIsRunningBacktest(false);
+      addToast("Backtest failed", "warning");
+      console.error("[Backtest] Submission error:", submitError);
     }
   };
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig(({ mode }) => {
           target: backtesterTarget,
           changeOrigin: true,
           secure: false,
-          rewrite: (path) => path.replace(/^\/backtester-api\/?$/, backtesterEndpoint),
+          rewrite: (path) => path.replace(/^\/backtester-api/, backtesterEndpoint),
         },
 
         "/api": {


### PR DESCRIPTION
implemented the updated async backtest api endpoints. now upon strategy submission, our client receives an ID and continuously polls every 2000 ms to check the status of our request. response bodies & error messages are console logged.

another addition I think should be added next would be log captures. Our backtest logs a ton of information throughout the course of executing a request, and those logs should be captured and displayed on the frontend. This can be handled in a separate issue.

demo [here](https://gyazo.com/43022a084aed0cc6e3d7ebe743350534)
