### PR TITLE
fix(cicd): tf s3 backend in workflows

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -66,7 +66,7 @@ jobs:
           cat > backend.hcl <<EOF
           bucket         = "hqg-prod-terraform-state"
           key            = "hqg-prod-dashboard/prod/terraform.tfstate"
-          region         = "${AWS_REGION}"
+          region         = "us-east-1"
           dynamodb_table = "hqg-prod-terraform-locks"
           encrypt        = true
           EOF

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -73,7 +73,7 @@ jobs:
           cat > backend.hcl <<EOF
           bucket         = "hqg-prod-terraform-state"
           key            = "hqg-prod-dashboard/prod/terraform.tfstate"
-          region         = "${AWS_REGION}"
+          region         = "us-east-1"
           dynamodb_table = "hqg-prod-terraform-locks"
           encrypt        = true
           EOF


### PR DESCRIPTION
I'm lowkey an idiot....

Last prod deploy didn't actually deploy... lol

For storing terraform state, I was using a terraform backend, which requires you to have backend.tf and backend.hcl files locally. I didn't want to store these locally since not everyone's environment would use them, but forgot to hardcode them in the workflow files. This should hopefully fix the prod deployment (praying it doesn't blow it all up)