### PR TITLE
Feat/#118 str seed upload date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 aws/lambda_layers/*/build/
 
 __pycache__/
+.codex

--- a/frontend/app/components/strategy-table.tsx
+++ b/frontend/app/components/strategy-table.tsx
@@ -27,6 +27,7 @@ export default function StrategyTable({
       day: "numeric",
       hour: "2-digit",
       minute: "2-digit",
+      timeZoneName: "short",
     });
   };
 

--- a/frontend/app/routes/create-strategy.tsx
+++ b/frontend/app/routes/create-strategy.tsx
@@ -221,7 +221,14 @@ export default function CreateStrategy() {
                 <div className="font-semibold text-white">{selectedTemplate.name}</div>
                 <div className="text-slate-400 text-xs">
                   Owner: {selectedTemplate.owner_display ?? selectedTemplate.owner ?? "—"} · Updated:{" "}
-                  {selectedTemplate.updated_at ? new Date(selectedTemplate.updated_at).toLocaleString() : "-"}
+                  {selectedTemplate.updated_at ? new Date(selectedTemplate.updated_at).toLocaleString("en-US", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                    timeZoneName: "short",
+                  }) : "-"}
                 </div>
                 <div className="text-slate-300 text-xs line-clamp-3">
                   {selectedTemplate.description || "No description provided."}

--- a/frontend/app/routes/strategy/overview.tsx
+++ b/frontend/app/routes/strategy/overview.tsx
@@ -87,6 +87,7 @@ export default function StrategyOverview() {
         year: "numeric",
         hour: "2-digit",
         minute: "2-digit",
+        timeZoneName: "short",
       }),
     []
   );

--- a/infra/seed/main.py
+++ b/infra/seed/main.py
@@ -58,6 +58,7 @@ DESCRIPTION_MAX_CHARS = 75
 DEFAULT_BACKTEST_START_DATE = "2020-01-03"
 DEFAULT_BACKTEST_END_DATE = "2024-12-31"
 DEFAULT_BACKTEST_INITIAL_CAPITAL = 100000.0
+SEEDED_STRATEGY_TIMESTAMP = "2026-03-06T12:00:00-05:00"
 
 BACKTEST_POLL_INTERVAL_SECONDS = 2.0
 BACKTEST_POLL_TIMEOUT_SECONDS = 900
@@ -679,8 +680,8 @@ def seed_tables(
         "owner_display": owner_display,
         "entrypoint": entrypoint,
         "current_version": VERSION,
-        "created_at": now,
-        "updated_at": now,
+        "created_at": SEEDED_STRATEGY_TIMESTAMP,
+        "updated_at": SEEDED_STRATEGY_TIMESTAMP,
         "description": description,
     }
     strategies.put_item(Item=strategy_item)


### PR DESCRIPTION
- Seeds a constant created and updated date for the 5 seeding strategies. I just set this to the time that we first deployed a functional version of the dashboard, 3/6/26
- Changed some frontend logic for the display of the last updated time. Made it so the time is translated to the user's local time zone.
- Added .codex to .gitignore because my codex keeps generating that file for some reason (always empty too lol)