### PR TITLE
Feat: ethan graph with bt-provided weights

### DIFF
--- a/frontend/app/api/backtest.ts
+++ b/frontend/app/api/backtest.ts
@@ -59,6 +59,11 @@ export type BacktestCandle = {
   close: number;
 };
 
+export type BacktestWeightSnapshot = {
+  time: number;
+  weights: { [ticker: string]: number };
+};
+
 export type BacktestParameters = {
   name: string;
   starting_equity: number;
@@ -72,6 +77,7 @@ export type BacktestResponse = {
   metrics: Metrics;
   candles: BacktestCandle[];
   orders: BacktestOrder[];
+  holding_weights: BacktestWeightSnapshot[];
 };
 
 export type BacktestRequest = {

--- a/frontend/app/api/backtest.ts
+++ b/frontend/app/api/backtest.ts
@@ -15,27 +15,40 @@ export const backtesterApi = axios.create({
 export type BacktestOrder = {
   id: string;
   timestamp: string;
-  symbol: string;
-  action: "Buy" | "Sell" | "buy" | "sell";
+  ticker: string;
+  type: "Buy" | "Sell";
   shares: number;
   price: number;
 };
 
 export type Metrics = {
-  total_return: number;
-  annualized_return: number;
-  sharpe_ratio: number;
-  max_drawdown: number;
-  win_rate: number;
-  total_orders: number;
+  // equity stats
+  final_portfolio_value: number;
+  fees: number;
+  net_profit: number;
+  volume: number;
+
+  // ratios
+  sharpe: number;
   sortino: number;
+  calmar?: number | null;
+  psr: number;
+
+  // return
+  total_pct_return: number;
+  annualized_return?: number | null;
+
+  // risk
+  ann_vol: number;
+  max_drawdown: number;
+  max_drawdown_duration: number;
+  var_95: number;
+  cvar_95: number;
+
+  // benchmark
   alpha: number;
   beta: number;
-  psr: number;
-  avg_win: number;
-  avg_loss: number;
-  annualized_variance?: number;
-  annualized_std?: number;
+  total_orders: number;
 };
 
 export type BacktestCandle = {
@@ -53,18 +66,10 @@ export type BacktestParameters = {
   end_date: string;
 };
 
-export type EquityStats = {
-  equity: number;
-  fees: number;
-  net_profit: number;
-  return_pct: number;
-  volume: number;
-};
 
 export type BacktestResponse = {
   parameters: BacktestParameters;
   metrics: Metrics;
-  equity_stats: EquityStats;
   candles: BacktestCandle[];
   orders: BacktestOrder[];
 };

--- a/frontend/app/api/backtestMetrics.ts
+++ b/frontend/app/api/backtestMetrics.ts
@@ -91,11 +91,12 @@ export type FinalizeBacktestRunResponse = {
   strategy_version?: number | string;
   backtest_params: BacktestParams;
   metrics: Record<string, unknown>;
-  net_pnl?: number;
+  annualized_return?: number;
   sharpe?: number;
-  win_rate?: number;
   max_drawdown?: number;
-  trades_count?: number;
+  ann_vol?: number;
+  var_95?: number;
+  beta?: number;
   s3_bucket: string;
   s3_key: string;
 };

--- a/frontend/app/routes/strategy/backtest.tsx
+++ b/frontend/app/routes/strategy/backtest.tsx
@@ -846,23 +846,23 @@ function BacktestOrdersTable({ orders, logs, showPlaceholder, animatePlaceholder
   const [page, setPage] = useState(1);
   const [pageInput, setPageInput] = useState("1");
   const [pageSize, setPageSize] = useState(DEFAULT_EXECUTION_LOG_PAGE_SIZE);
-  const [symbolFilter, setSymbolFilter] = useState("");
-  const [actionFilter, setActionFilter] = useState<"all" | "buy" | "sell">("all");
+  const [tickerFilter, setSymbolFilter] = useState("");
+  const [typeFilter, setTypeFilter] = useState<"all" | "buy" | "sell">("all");
 
   useEffect(() => {
     setPage(1);
     setPageInput("1");
-  }, [orders, pageSize, symbolFilter, actionFilter, activeTab]);
+  }, [orders, pageSize, tickerFilter, typeFilter, activeTab]);
 
   const filteredOrders = useMemo(() => {
-    const normalizedSymbol = symbolFilter.trim().toLowerCase();
+    const normalizedTicker = tickerFilter.trim().toLowerCase();
     return orders.filter((order) => {
-      const matchesSymbol = !normalizedSymbol || order.symbol.toLowerCase().includes(normalizedSymbol);
-      const normalizedAction = String(order.action).toLowerCase();
-      const matchesAction = actionFilter === "all" || normalizedAction === actionFilter;
-      return matchesSymbol && matchesAction;
+      const matchesTicker = !normalizedTicker || order.ticker.toLowerCase().includes(normalizedTicker);
+      const normalizedType = String(order.type).toLowerCase();
+      const matchesType = typeFilter === "all" || normalizedType === typeFilter;
+      return matchesTicker && matchesType;
     });
-  }, [actionFilter, orders, symbolFilter]);
+  }, [typeFilter, orders, tickerFilter]);
 
   const totalPages = Math.max(1, Math.ceil(filteredOrders.length / pageSize));
   const currentPage = Math.min(page, totalPages);
@@ -989,11 +989,11 @@ function BacktestOrdersTable({ orders, logs, showPlaceholder, animatePlaceholder
         ) : filteredOrders.length === 0 ? (
           <div className="space-y-4">
             <ExecutionFilters
-              symbolFilter={symbolFilter}
-              actionFilter={actionFilter}
+              tickerFilter={tickerFilter}
+              typeFilter={typeFilter}
               pageSize={pageSize}
-              onSymbolFilterChange={setSymbolFilter}
-              onActionFilterChange={setActionFilter}
+              onTickerFilterChange={setSymbolFilter}
+              onTypeFilterChange={setTypeFilter}
               onPageSizeChange={setPageSize}
             />
             <div className="rounded-2xl border border-dashed border-slate-800 bg-slate-900/20 px-4 py-8 text-center text-sm text-slate-400">
@@ -1003,11 +1003,11 @@ function BacktestOrdersTable({ orders, logs, showPlaceholder, animatePlaceholder
         ) : (
           <div className="space-y-4">
             <ExecutionFilters
-              symbolFilter={symbolFilter}
-              actionFilter={actionFilter}
+              tickerFilter={tickerFilter}
+              typeFilter={typeFilter}
               pageSize={pageSize}
-              onSymbolFilterChange={setSymbolFilter}
-              onActionFilterChange={setActionFilter}
+              onTickerFilterChange={setSymbolFilter}
+              onTypeFilterChange={setTypeFilter}
               onPageSizeChange={setPageSize}
             />
 
@@ -1028,12 +1028,12 @@ function BacktestOrdersTable({ orders, logs, showPlaceholder, animatePlaceholder
               </thead>
               <tbody>
                 {visibleOrders.map((order) => {
-                  const isBuy = String(order.action).toLowerCase() === "buy";
+                  const isBuy = String(order.type).toLowerCase() === "buy";
                   const orderType = isBuy ? "Buy" : "Sell";
                   return (
                     <tr key={order.id} className="border-t border-slate-800 text-slate-200">
                       <td className="px-3 py-3">{dateFormatter.format(new Date(order.timestamp))}</td>
-                      <td className="px-3 py-3 font-semibold">{order.symbol}</td>
+                      <td className="px-3 py-3 font-semibold">{order.ticker}</td>
                       <td className="px-3 py-3">
                         <span className={`font-semibold ${isBuy ? "text-emerald-400" : "text-rose-400"}`}>
                           {orderType}
@@ -1096,41 +1096,41 @@ function BacktestOrdersTable({ orders, logs, showPlaceholder, animatePlaceholder
 type ExecutionFiltersProps = {
   pageSize: number;
   onPageSizeChange: (value: number) => void;
-  symbolFilter?: string;
-  actionFilter?: "all" | "buy" | "sell";
-  onSymbolFilterChange?: (value: string) => void;
-  onActionFilterChange?: (value: "all" | "buy" | "sell") => void;
+  tickerFilter?: string;
+  typeFilter?: "all" | "buy" | "sell";
+  onTickerFilterChange?: (value: string) => void;
+  onTypeFilterChange?: (value: "all" | "buy" | "sell") => void;
 };
 
 function ExecutionFilters({
   pageSize,
   onPageSizeChange,
-  symbolFilter,
-  actionFilter,
-  onSymbolFilterChange,
-  onActionFilterChange,
+  tickerFilter,
+  typeFilter,
+  onTickerFilterChange,
+  onTypeFilterChange,
 }: ExecutionFiltersProps) {
   return (
     <div className="flex flex-wrap items-end gap-3 border-y border-slate-800 py-4">
-      {symbolFilter !== undefined && onSymbolFilterChange !== undefined && (
+      {tickerFilter !== undefined && onTickerFilterChange !== undefined && (
         <label className="space-y-1">
           <span className="text-xs uppercase tracking-[0.22em] text-slate-500">Ticker</span>
           <input
             type="text"
-            value={symbolFilter}
-            onChange={(event) => onSymbolFilterChange(event.target.value)}
-            placeholder="Filter symbol"
+            value={tickerFilter}
+            onChange={(event) => onTickerFilterChange(event.target.value)}
+            placeholder="Filter ticker"
             className="rounded-xl border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 placeholder-slate-500 focus:border-fuchsia-500 focus:outline-none"
           />
         </label>
       )}
 
-      {actionFilter !== undefined && onActionFilterChange !== undefined && (
+      {typeFilter !== undefined && onTypeFilterChange !== undefined && (
         <label className="space-y-1">
           <span className="text-xs uppercase tracking-[0.22em] text-slate-500">Side</span>
           <select
-            value={actionFilter}
-            onChange={(event) => onActionFilterChange(event.target.value as "all" | "buy" | "sell")}
+            value={typeFilter}
+            onChange={(event) => onTypeFilterChange(event.target.value as "all" | "buy" | "sell")}
             className="rounded-xl border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-slate-100 focus:border-fuchsia-500 focus:outline-none"
           >
             <option value="all">All</option>
@@ -1194,7 +1194,7 @@ const toFiniteNumber = (value: unknown): number | null => {
   return value;
 };
 
-const toDecimal = (value: number | undefined) => (Number.isFinite(value) ? (value as number) : null);
+const toDecimal = (value: number | null | undefined) => (Number.isFinite(value) ? (value as number) : null);
 
 const formatNumber = (value: number | null, decimals = 2) =>
   value === null ? "—" : value.toFixed(decimals);
@@ -1212,32 +1212,36 @@ const formatPercentValue = (value: number | null, decimals = 2) => {
 const formatMoney = (value: number | null) => (value === null ? "—" : currencyFormatter.format(value));
 
 const buildMetrics = (metrics?: Metrics): BacktestMetric[] => {
-  const sharpe = toDecimal(metrics?.sharpe_ratio);
+  const sharpe = toDecimal(metrics?.sharpe);
   const sortino = toDecimal(metrics?.sortino);
+  const calmar = toDecimal(metrics?.calmar);
   const alpha = toDecimal(metrics?.alpha);
   const beta = toDecimal(metrics?.beta);
   const psr = toDecimal(metrics?.psr);
-  const winRate = toDecimal(metrics?.win_rate);
   const maxDrawdown = toDecimal(metrics?.max_drawdown);
+  const maxDrawdownDuration = toDecimal(metrics?.max_drawdown_duration);
   const totalOrders = toDecimal(metrics?.total_orders);
-  const avgWin = toDecimal(metrics?.avg_win);
-  const avgLoss = toDecimal(metrics?.avg_loss);
-  const totalReturn = toDecimal(metrics?.total_return);
+  const totalReturn = toDecimal(metrics?.total_pct_return);
   const annualizedReturn = toDecimal(metrics?.annualized_return);
+  const annVol = toDecimal(metrics?.ann_vol);
+  const var95 = toDecimal(metrics?.var_95);
+  const cvar95 = toDecimal(metrics?.cvar_95);
 
   return [
     { id: "sharpe", label: "Sharpe", value: formatNumber(sharpe), column: "left" },
     { id: "sortino", label: "Sortino", value: formatNumber(sortino), column: "left" },
+    { id: "calmar", label: "Calmar", value: formatNumber(calmar), column: "left" },
     { id: "alpha", label: "Alpha", value: formatNumber(alpha), column: "left" },
     { id: "beta", label: "Beta", value: formatNumber(beta), column: "left" },
     { id: "psr", label: "PSR", value: formatNumber(psr), column: "left" },
-    { id: "winRate", label: "Win Rate", value: formatPercent(winRate), column: "left" },
     { id: "totalReturn", label: "Total Return", value: formatPercent(totalReturn), column: "right" },
-    { id: "annualizedReturn", label: "Ann. Return", value: formatPercent(annualizedReturn), column: "right" },
+    { id: "annualizedReturn", label: "CAGR", value: formatPercent(annualizedReturn), column: "right" },
+    { id: "annVol", label: "Ann. Volatility", value: formatPercent(annVol), column: "right" },
     { id: "maxDrawdown", label: "Max Drawdown", value: formatPercent(maxDrawdown), column: "right" },
-    { id: "totalOrders", label: "Total Orders", value: totalOrders === null ? "—" : numberFormatter.format(totalOrders), column: "right" },
-    { id: "avgWin", label: "Avg Win %", value: formatPercent(avgWin), column: "right" },
-    { id: "avgLoss", label: "Avg Loss %", value: formatPercent(avgLoss), column: "right" },
+    { id: "maxDrawdownDuration", label: "Max DD Duration", value: maxDrawdownDuration === null ? "—" : `${numberFormatter.format(maxDrawdownDuration)} bars`, column: "right" },
+    { id: "var95", label: "VaR (95%)", value: formatPercent(var95), column: "right" },
+    { id: "cvar95", label: "CVaR (95%)", value: formatPercent(cvar95), column: "right" },
+    { id: "totalOrders", label: "Total Orders", value: totalOrders === null ? "—" : numberFormatter.format(totalOrders), column: "left" },
   ];
 };
 
@@ -1306,17 +1310,17 @@ const buildAllocationSeries = (
 
     while (index < sortedOrders.length && sortedOrders[index].timestamp === timestamp) {
       const order = sortedOrders[index];
-      const direction = String(order.action).toLowerCase() === "buy" ? 1 : -1;
+      const direction = String(order.type).toLowerCase() === "buy" ? 1 : -1;
       const shares = direction * order.shares;
-      const nextQuantity = (holdings.get(order.symbol) ?? 0) + shares;
+      const nextQuantity = (holdings.get(order.ticker) ?? 0) + shares;
 
       if (Math.abs(nextQuantity) < 1e-9) {
-        holdings.delete(order.symbol);
+        holdings.delete(order.ticker);
       } else {
-        holdings.set(order.symbol, nextQuantity);
+        holdings.set(order.ticker, nextQuantity);
       }
 
-      latestPrices.set(order.symbol, order.price);
+      latestPrices.set(order.ticker, order.price);
       cash -= shares * order.price;
       index += 1;
     }
@@ -1395,7 +1399,7 @@ const buildOrders = (orders?: BacktestOrder[]): BacktestOrder[] => {
 
   return orders.map((order, index) => ({
     ...order,
-    id: order.id || `${order.timestamp}-${order.symbol}-${index}`,
+    id: order.id || `${order.timestamp}-${order.ticker}-${index}`,
   }));
 };
 
@@ -1667,11 +1671,12 @@ function RechartsAllocationChart({
 const buildEquityStats = (data: BacktestResponse | null): EquityStat[] => {
   if (!data) return [];
 
-  const finalEquity = toDecimal(data.equity_stats?.equity);
-  const fees = toDecimal(data.equity_stats?.fees);
-  const netProfit = toDecimal(data.equity_stats?.net_profit);
-  const returnPct = toDecimal(data.equity_stats?.return_pct);
-  const volume = toDecimal(data.equity_stats?.volume);
+  const m = data.metrics;
+  const finalEquity = toDecimal(m?.final_portfolio_value);
+  const fees = toDecimal(m?.fees);
+  const netProfit = toDecimal(m?.net_profit);
+  const returnPct = toDecimal(m?.total_pct_return);
+  const volume = toDecimal(m?.volume);
 
   const profitAccent = netProfit !== null && netProfit >= 0 ? "text-emerald-300" : "text-rose-300";
   const returnAccent = returnPct !== null && returnPct >= 0 ? "text-emerald-300" : "text-rose-300";
@@ -1679,7 +1684,7 @@ const buildEquityStats = (data: BacktestResponse | null): EquityStat[] => {
   return [
     { id: "finalEquity", label: "Final Equity", value: formatMoney(finalEquity), accentClass: "text-white" },
     { id: "netProfit", label: "Net Profit", value: formatMoney(netProfit), accentClass: profitAccent },
-    { id: "return", label: "Return", value: formatPercentValue(returnPct), accentClass: returnAccent },
+    { id: "return", label: "Return", value: formatPercent(returnPct), accentClass: returnAccent },
     { id: "fees", label: "Fees", value: formatMoney(fees), accentClass: "text-white" },
     { id: "volume", label: "Volume", value: volume === null ? "—" : numberFormatter.format(volume), accentClass: "text-white" },
   ];

--- a/frontend/app/routes/strategy/backtest.tsx
+++ b/frontend/app/routes/strategy/backtest.tsx
@@ -26,6 +26,7 @@ import {
   type BacktestCandle,
   type BacktestOrder,
   type BacktestResponse,
+  type BacktestWeightSnapshot,
   type Metrics,
 } from "~/api/backtest";
 import { finalizeBacktestRun, gzipJson, presignBacktestRunUpload, uploadPresignedPost } from "~/api/backtestMetrics";
@@ -83,8 +84,7 @@ type BacktestMetricsProps = {
 type StrategyEquityChartProps = {
   stats: EquityStat[];
   candles: EquityCandle[];
-  orders: BacktestOrder[];
-  startingEquity: number;
+  holdingWeightsSeries: { data: AllocationPoint[]; keys: string[] };
   onSave: () => void;
   isSaving: boolean;
   isSaveDisabled: boolean;
@@ -105,7 +105,7 @@ type ExecutionPanelTab = "orders" | "logs" | "warnings";
 
 const DEFAULT_EXECUTION_LOG_PAGE_SIZE = 10;
 const EXECUTION_LOG_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
-const ALLOCATION_COLORS = [
+const WEIGHT_CHART_COLORS = [
   "#60a5fa",
   "#34d399",
   "#fbbf24",
@@ -114,7 +114,12 @@ const ALLOCATION_COLORS = [
   "#fb7185",
   "#22d3ee",
   "#f59e0b",
+  "#818cf8",
+  "#2dd4bf",
+  "#e879f9",
+  "#38bdf8",
 ];
+const CASH_COLOR = "#64748b";
 
 const currencyFormatter = new Intl.NumberFormat("en-US", {
   style: "currency",
@@ -398,14 +403,10 @@ export default function StrategyBacktest() {
   const candles = useMemo(() => buildCandles(backtestData?.candles), [backtestData]);
   const orders = useMemo(() => buildOrders(backtestData?.orders), [backtestData]);
   const equityStats = useMemo(() => buildEquityStats(backtestData), [backtestData]);
-  const chartStartingEquity = useMemo(() => {
-    const responseEquity = backtestData?.parameters?.starting_equity;
-    if (typeof responseEquity === "number" && Number.isFinite(responseEquity)) {
-      return responseEquity;
-    }
-    const parsed = Number.parseFloat((lastBacktestParamValues.startingEquity ?? "0").replace(/,/g, ""));
-    return Number.isFinite(parsed) ? parsed : 0;
-  }, [backtestData, lastBacktestParamValues.startingEquity]);
+  const holdingWeightsSeries = useMemo(
+    () => buildHoldingWeightsSeries(backtestData?.holding_weights),
+    [backtestData]
+  );
 
   return (
     <SkeletonTheme baseColor={skeletonBaseColor} highlightColor={skeletonHighlightColor}>
@@ -426,8 +427,7 @@ export default function StrategyBacktest() {
             <StrategyEquityChart
               stats={equityStats}
               candles={candles}
-              orders={orders}
-              startingEquity={chartStartingEquity}
+              holdingWeightsSeries={holdingWeightsSeries}
               onSave={handleSaveResults}
               isSaving={isSavingBacktest}
               isSaveDisabled={isSaveDisabled}
@@ -564,8 +564,7 @@ function BacktestMetrics({ metrics, showPlaceholder, animatePlaceholder }: Backt
 function StrategyEquityChart({
   stats,
   candles,
-  orders,
-  startingEquity,
+  holdingWeightsSeries,
   onSave,
   isSaving,
   isSaveDisabled,
@@ -581,10 +580,6 @@ function StrategyEquityChart({
   const hoverDotRef = useRef<HTMLDivElement | null>(null);
   const [chartType, setChartType] = useState<EquityChartType>("candles");
   const linePoints = useMemo(() => buildLinePoints(candles), [candles]);
-  const allocationSeries = useMemo(
-    () => buildAllocationSeries(candles, orders, startingEquity),
-    [candles, orders, startingEquity]
-  );
 
   useEffect(() => {
     if (chartType !== "candles") {
@@ -814,7 +809,7 @@ function StrategyEquityChart({
         </div>
       ) : chartType === "allocation" ? (
         <div className="mt-5 min-h-[420px] flex-1 overflow-hidden rounded-2xl">
-          <RechartsAllocationChart series={allocationSeries} />
+          <RechartsAllocationChart series={holdingWeightsSeries} />
         </div>
       ) : chartType === "line" ? (
         <div className="mt-5 min-h-[420px] flex-1 overflow-hidden rounded-2xl">
@@ -1272,128 +1267,6 @@ const buildLinePoints = (candles?: EquityCandle[]): EquityLinePoint[] => {
     }));
 };
 
-const buildAllocationSeries = (
-  candles: EquityCandle[],
-  orders: BacktestOrder[],
-  startingEquity: number
-) => {
-  if (!Array.isArray(candles) || candles.length === 0 || !Number.isFinite(startingEquity) || startingEquity <= 0) {
-    return {
-      data: [] as AllocationPoint[],
-      keys: [] as string[],
-    };
-  }
-
-  const timeline = [...candles].sort((a, b) => Number(a.time) - Number(b.time)).map((candle) => Number(candle.time));
-  const initialSnapshot: AllocationPoint = {
-    time: timeline[0] ?? 0,
-    Cash: 100,
-  };
-
-  if (!Array.isArray(orders) || orders.length === 0) {
-    return {
-      data: timeline.map((time) => ({ time, Cash: 100 })),
-      keys: ["Cash"],
-    };
-  }
-
-  const sortedOrders = [...orders].sort(
-    (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
-  );
-  const holdings = new Map<string, number>();
-  const latestPrices = new Map<string, number>();
-  let cash = startingEquity;
-  const snapshots: AllocationPoint[] = [];
-
-  for (let index = 0; index < sortedOrders.length; ) {
-    const timestamp = sortedOrders[index].timestamp;
-
-    while (index < sortedOrders.length && sortedOrders[index].timestamp === timestamp) {
-      const order = sortedOrders[index];
-      const direction = String(order.type).toLowerCase() === "buy" ? 1 : -1;
-      const shares = direction * order.shares;
-      const nextQuantity = (holdings.get(order.ticker) ?? 0) + shares;
-
-      if (Math.abs(nextQuantity) < 1e-9) {
-        holdings.delete(order.ticker);
-      } else {
-        holdings.set(order.ticker, nextQuantity);
-      }
-
-      latestPrices.set(order.ticker, order.price);
-      cash -= shares * order.price;
-      index += 1;
-    }
-
-    const assetValues = new Map<string, number>();
-    let totalValue = Math.max(cash, 0);
-
-    for (const [symbol, quantity] of holdings.entries()) {
-      const price = latestPrices.get(symbol);
-      if (!price || !Number.isFinite(price)) continue;
-      const marketValue = Math.max(quantity * price, 0);
-      if (marketValue <= 0) continue;
-      assetValues.set(symbol, marketValue);
-      totalValue += marketValue;
-    }
-
-    if (totalValue <= 0) {
-      continue;
-    }
-
-    const point: AllocationPoint = { time: Math.floor(new Date(timestamp).getTime() / 1000) };
-    for (const [symbol, marketValue] of assetValues.entries()) {
-      point[symbol] = (marketValue / totalValue) * 100;
-    }
-    point.Cash = (Math.max(cash, 0) / totalValue) * 100;
-    snapshots.push(point);
-  }
-
-  const normalizedSnapshots = [initialSnapshot, ...snapshots]
-    .sort((a, b) => a.time - b.time)
-    .filter((point, index, items) => index === 0 || point.time !== items[index - 1]?.time);
-
-  const keys = Array.from(
-    normalizedSnapshots.reduce((acc, point) => {
-      Object.keys(point).forEach((key) => {
-        if (key !== "time") acc.add(key);
-      });
-      return acc;
-    }, new Set<string>())
-  ).sort((a, b) => {
-    if (a === "Cash") return 1;
-    if (b === "Cash") return -1;
-    return a.localeCompare(b);
-  });
-
-  const data: AllocationPoint[] = [];
-  let snapshotIndex = 0;
-  let activeSnapshot = normalizedSnapshots[0];
-
-  for (const time of timeline) {
-    while (
-      snapshotIndex + 1 < normalizedSnapshots.length &&
-      normalizedSnapshots[snapshotIndex + 1] &&
-      normalizedSnapshots[snapshotIndex + 1].time <= time
-    ) {
-      snapshotIndex += 1;
-      activeSnapshot = normalizedSnapshots[snapshotIndex];
-    }
-
-    data.push(allocationPointFromSnapshot(time, activeSnapshot, keys));
-  }
-
-  return { data, keys };
-};
-
-const allocationPointFromSnapshot = (time: number, snapshot: AllocationPoint, keys: string[]) => {
-  const point: AllocationPoint = { time };
-  for (const key of keys) {
-    point[key] = snapshot[key] ?? 0;
-  }
-  return point;
-};
-
 const buildOrders = (orders?: BacktestOrder[]): BacktestOrder[] => {
   if (!Array.isArray(orders)) return [];
 
@@ -1600,10 +1473,20 @@ function RechartsAllocationChart({
   if (!series.data.length || !series.keys.length) {
     return (
       <div className="flex h-full min-h-[420px] items-center justify-center rounded-2xl border border-dashed border-slate-800 bg-slate-900/20 px-4 text-sm text-slate-400">
-        No allocation snapshots could be derived from this run&apos;s orders.
+        No holding weight snapshots available for this run.
       </div>
     );
   }
+
+  const nonCashKeys = series.keys.filter((k) => k !== "Cash");
+  const hasCash = series.keys.includes("Cash");
+  const renderKeys = [...nonCashKeys, ...(hasCash ? ["Cash"] : [])];
+
+  const colorForKey = (key: string) => {
+    if (key === "Cash") return CASH_COLOR;
+    const idx = nonCashKeys.indexOf(key);
+    return WEIGHT_CHART_COLORS[idx % WEIGHT_CHART_COLORS.length];
+  };
 
   return (
     <div className="grid h-full min-h-[420px] gap-4 lg:grid-cols-[minmax(0,1fr)_180px]">
@@ -1635,33 +1518,39 @@ function RechartsAllocationChart({
               cursor={{ stroke: "rgba(226,232,240,0.28)", strokeWidth: 1 }}
               isAnimationActive={false}
             />
-            {series.keys.map((key, index) => (
-              <Area
-                key={key}
-                type="stepAfter"
-                dataKey={key}
-                stackId="allocation"
-                stroke={ALLOCATION_COLORS[index % ALLOCATION_COLORS.length]}
-                fill={ALLOCATION_COLORS[index % ALLOCATION_COLORS.length]}
-                fillOpacity={0.72}
-                isAnimationActive={false}
-              />
-            ))}
+            {renderKeys.map((key) => {
+              const color = colorForKey(key);
+              return (
+                <Area
+                  key={key}
+                  type="stepAfter"
+                  dataKey={key}
+                  stackId="allocation"
+                  stroke={color}
+                  fill={color}
+                  fillOpacity={key === "Cash" ? 0.35 : 0.72}
+                  isAnimationActive={false}
+                />
+              );
+            })}
           </AreaChart>
         </ResponsiveContainer>
       </div>
       <aside className="rounded-2xl border border-slate-800/60 bg-slate-900/30 p-4">
         <p className="text-xs uppercase tracking-[0.18em] text-slate-500">Legend</p>
         <div className="mt-3 space-y-2">
-          {series.keys.map((key, index) => (
-            <div key={key} className="flex items-center gap-3 text-sm text-slate-200">
-              <span
-                className="h-3 w-3 rounded-full"
-                style={{ backgroundColor: ALLOCATION_COLORS[index % ALLOCATION_COLORS.length] }}
-              />
-              <span>{key}</span>
-            </div>
-          ))}
+          {renderKeys.map((key) => {
+            const color = colorForKey(key);
+            return (
+              <div key={key} className="flex items-center gap-3 text-sm text-slate-200">
+                <span
+                  className="h-3 w-3 rounded-full"
+                  style={{ backgroundColor: color, opacity: key === "Cash" ? 0.55 : 1 }}
+                />
+                <span className={key === "Cash" ? "text-slate-400" : ""}>{key}</span>
+              </div>
+            );
+          })}
         </div>
       </aside>
     </div>
@@ -1688,4 +1577,53 @@ const buildEquityStats = (data: BacktestResponse | null): EquityStat[] => {
     { id: "fees", label: "Fees", value: formatMoney(fees), accentClass: "text-white" },
     { id: "volume", label: "Volume", value: volume === null ? "—" : numberFormatter.format(volume), accentClass: "text-white" },
   ];
+};
+
+const buildHoldingWeightsSeries = (
+  snapshots?: BacktestWeightSnapshot[]
+): { data: Array<{ time: number; Cash: number; [ticker: string]: number }>; keys: string[] } => {
+  const empty = { data: [] as Array<{ time: number; Cash: number; [ticker: string]: number }>, keys: [] as string[] };
+  if (!Array.isArray(snapshots) || snapshots.length === 0) return empty;
+
+  const sorted = [...snapshots].sort((a, b) => a.time - b.time);
+
+  // Collect all ticker keys across all snapshots
+  const tickerSet = new Set<string>();
+  for (const snap of sorted) {
+    if (snap.weights) {
+      for (const ticker of Object.keys(snap.weights)) {
+        tickerSet.add(ticker);
+      }
+    }
+  }
+
+  const tickers = Array.from(tickerSet).sort((a, b) => a.localeCompare(b));
+
+  const data = sorted.map((snap) => {
+    const point: { time: number; Cash: number; [ticker: string]: number } = {
+      time: snap.time,
+      Cash: 0,
+    };
+
+    let weightSum = 0;
+    for (const ticker of tickers) {
+      const w = snap.weights?.[ticker] ?? 0;
+      // Weights come as fractions (0–1); convert to percentage
+      const pct = w * 100;
+      point[ticker] = Math.max(0, pct);
+      weightSum += w;
+    }
+
+    // Remainder goes to Cash
+    const cashWeight = Math.max(0, (1 - weightSum) * 100);
+    point.Cash = cashWeight;
+
+    return point;
+  });
+
+  // Include Cash in keys only if it's non-trivial at any point
+  const hasCash = data.some((p) => p.Cash > 0.05);
+  const keys = [...tickers, ...(hasCash ? ["Cash"] : [])];
+
+  return { data, keys };
 };

--- a/frontend/app/routes/strategy/results.tsx
+++ b/frontend/app/routes/strategy/results.tsx
@@ -119,30 +119,29 @@ export default function StrategyResults() {
               <th className="px-4 py-3 text-left font-medium">Strategy Version</th>
               <th className="px-4 py-3 text-left font-medium">Started</th>
               <th className="px-4 py-3 text-left font-medium">Parameters</th>
-              <th className="px-4 py-3 text-left font-medium">Net PnL</th>
               <th className="px-4 py-3 text-left font-medium">Sharpe</th>
-              <th className="px-4 py-3 text-left font-medium">Win Rate</th>
+              <th className="px-4 py-3 text-left font-medium">CAGR</th>
               <th className="px-4 py-3 text-left font-medium">Drawdown</th>
-              <th className="px-4 py-3 text-left font-medium">Trades</th>
+              <th className="px-4 py-3 text-left font-medium">Volatility</th>
+              <th className="px-4 py-3 text-left font-medium">VaR (95%)</th>
+              <th className="px-4 py-3 text-left font-medium">Beta</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-900 text-slate-200">
             {isSavedBacktestRunsLoading ? (
               <tr>
-                <td className="px-4 py-6 text-sm text-slate-400" colSpan={10}>
+                <td className="px-4 py-6 text-sm text-slate-400" colSpan={11}>
                   Loading…
                 </td>
               </tr>
             ) : null}
 
             {sortedRuns.map((run) => {
-              const pnl = run.net_pnl ?? 0;
-              const pnlClass = pnl >= 0 ? "text-emerald-400" : "text-rose-400";
               const name = run.name ?? "—";
               const start = run.backtest_params?.start_date ?? "—";
               const end = run.backtest_params?.end_date ?? "—";
               const equity = run.backtest_params?.initial_capital ?? 0;
-              const drawdown = typeof run.max_drawdown === "number" ? -run.max_drawdown : null;
+              const drawdown = typeof run.max_drawdown === "number" ? run.max_drawdown : null;
               return (
                 <tr
                   key={run.run_id}
@@ -168,20 +167,23 @@ export default function StrategyResults() {
                       <span className="text-slate-500">Equity:</span> {currencyFormatter.format(equity)}
                     </div>
                   </td>
-                  <td className={`px-4 py-4 align-top font-mono ${pnlClass}`}>
-                    {currencyFormatter.format(pnl)}
-                  </td>
                   <td className="px-4 py-4 align-top font-semibold text-white">
                     {typeof run.sharpe === "number" ? run.sharpe.toFixed(2) : "—"}
                   </td>
-                  <td className="px-4 py-4 align-top font-semibold text-emerald-300">
-                    {typeof run.win_rate === "number" ? formatPercent(run.win_rate) : "—"}
+                  <td className="px-4 py-4 align-top font-semibold text-white">
+                    {typeof run.annualized_return === "number" ? formatPercent(run.annualized_return) : "—"}
                   </td>
                   <td className="px-4 py-4 align-top font-semibold text-rose-300">
                     {drawdown === null ? "—" : formatPercent(drawdown)}
                   </td>
                   <td className="px-4 py-4 align-top font-semibold text-slate-200">
-                    {typeof run.trades_count === "number" ? run.trades_count : "—"}
+                    {typeof run.ann_vol === "number" ? formatPercent(run.ann_vol) : "—"}
+                  </td>
+                  <td className="px-4 py-4 align-top font-semibold text-slate-200">
+                    {typeof run.var_95 === "number" ? formatPercent(run.var_95) : "—"}
+                  </td>
+                  <td className="px-4 py-4 align-top font-semibold text-slate-200">
+                    {typeof run.beta === "number" ? run.beta.toFixed(2) : "—"}
                   </td>
                 </tr>
               );


### PR DESCRIPTION
Using the weights passed from backtester to make ethan graphs with precision.

UI future improvement: stack candles (top) and weights (bottom) on a shared x-axis for easier performance/benchmark vs. holdings comparison, helping researchers pinpoint model wins and losses.