### PR TITLE
Feat: Config Tab

### DIFF
--- a/aws/lambdas/strategies/main.py
+++ b/aws/lambdas/strategies/main.py
@@ -184,12 +184,6 @@ def update_strategy(strategy_id: Optional[str], body: Dict[str, Any]) -> Dict[st
 # Helpers
 # ----------------------------
 
-DEFAULT_CONFIG = """{
-  "WINDOW": 21,
-  "STOP_LOSS": 0.05
-}"""
-
-
 def _copy_artifacts_from_source(
     source_strategy_id: str,
     target_strategy_id: str,
@@ -253,13 +247,13 @@ def _copy_artifacts_from_source(
             s3_key=target_key,
         )
 
-    # If no config.json existed in source, scaffold a default one.
+    # If no config.json existed in source, scaffold an empty one.
     if not config_uploaded:
         target_key = f"{target_strategy_id}/v{target_version}/config.json"
         s3.put_object(
             Bucket=ARTIFACT_BUCKET,
             Key=target_key,
-            Body=DEFAULT_CONFIG.encode("utf-8"),
+            Body=b"",
         )
         _write_artifact_metadata(
             strategy_id=target_strategy_id,

--- a/aws/lambdas/strategies/main.py
+++ b/aws/lambdas/strategies/main.py
@@ -184,6 +184,12 @@ def update_strategy(strategy_id: Optional[str], body: Dict[str, Any]) -> Dict[st
 # Helpers
 # ----------------------------
 
+DEFAULT_CONFIG = """{
+  "WINDOW": 21,
+  "STOP_LOSS": 0.05
+}"""
+
+
 def _copy_artifacts_from_source(
     source_strategy_id: str,
     target_strategy_id: str,
@@ -197,6 +203,7 @@ def _copy_artifacts_from_source(
     artifacts = resp.get("Items", [])
 
     readme_uploaded = False
+    config_uploaded = False
 
     for artifact in artifacts:
         artifact_id = artifact["artifact_id"]
@@ -220,6 +227,8 @@ def _copy_artifacts_from_source(
             readme_uploaded = True
             _put_readme(target_key, readme_content)
         else:
+            if artifact_id.lower() == "config.json":
+                config_uploaded = True
             s3.copy_object(
                 Bucket=ARTIFACT_BUCKET,
                 CopySource={"Bucket": ARTIFACT_BUCKET, "Key": source_s3_key},
@@ -240,6 +249,21 @@ def _copy_artifacts_from_source(
         _write_artifact_metadata(
             strategy_id=target_strategy_id,
             artifact_id="README.md",
+            version=target_version,
+            s3_key=target_key,
+        )
+
+    # If no config.json existed in source, scaffold a default one.
+    if not config_uploaded:
+        target_key = f"{target_strategy_id}/v{target_version}/config.json"
+        s3.put_object(
+            Bucket=ARTIFACT_BUCKET,
+            Key=target_key,
+            Body=DEFAULT_CONFIG.encode("utf-8"),
+        )
+        _write_artifact_metadata(
+            strategy_id=target_strategy_id,
+            artifact_id="config.json",
             version=target_version,
             s3_key=target_key,
         )

--- a/frontend/app/api/backtest.ts
+++ b/frontend/app/api/backtest.ts
@@ -74,6 +74,7 @@ export type BacktestRequest = {
   start_date: string;
   end_date: string;
   initial_capital: number;
+  config_params?: Record<string, unknown>;
 };
 
 export type JobStatus = "PENDING" | "RUNNING" | "COMPLETED" | "FAILED" | "CANCELLED";

--- a/frontend/app/routes/strategy/backtest.tsx
+++ b/frontend/app/routes/strategy/backtest.tsx
@@ -1,3 +1,4 @@
+import Editor from "@monaco-editor/react";
 import { type FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
   CandlestickSeries,
@@ -29,6 +30,7 @@ import {
   type Metrics,
 } from "~/api/backtest";
 import { finalizeBacktestRun, gzipJson, presignBacktestRunUpload, uploadPresignedPost } from "~/api/backtestMetrics";
+import { fetchStrategyArtifactContent } from "~/api/strategyArtifacts";
 import { useStrategyWorkspace } from "./layout";
 
 type BacktestParameter = {
@@ -139,6 +141,7 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
 export default function StrategyBacktest() {
   const {
     strategy,
+    files,
     entrypoint,
     addToast,
     isSaving: isWorkspaceSaving,
@@ -156,6 +159,10 @@ export default function StrategyBacktest() {
     setActiveBacktestSource,
     setActiveSavedRunId,
   } = useStrategyWorkspace();
+
+  const configFile = files.find(
+    (f) => f.path === "config.json" || f.path.endsWith("/config.json")
+  );
   const [isRunningBacktest, setIsRunningBacktest] = useState(false);
   const [isSavingBacktest, setIsSavingBacktest] = useState(false);
   const [latestBacktestLogs, setLatestBacktestLogs] = useState<string[]>([]);
@@ -166,6 +173,14 @@ export default function StrategyBacktest() {
       if (pollIntervalRef.current !== null) clearInterval(pollIntervalRef.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (!configFile || !strategy || configFile.content) return;
+    fetchStrategyArtifactContent(strategy.id, configFile.path)
+      .then((content) => { if (content) updateFileContent(configFile.path, content); })
+      .catch(() => {});
+  }, [configFile, strategy]);
+
   const backtestData = latestBacktestData;
   const currentEntrypointContent = typeof entrypoint?.content === "string" ? entrypoint.content : null;
   const lastRunParameters = useMemo(
@@ -190,6 +205,22 @@ export default function StrategyBacktest() {
       return;
     }
 
+    let configParams: Record<string, unknown> | undefined;
+    const configContent = configFile?.content?.trim();
+    if (configContent) {
+      try {
+        const parsed = JSON.parse(configContent);
+        if (typeof parsed !== "object" || Array.isArray(parsed) || parsed === null) {
+          addToast("config.json must be a JSON object.", "warning");
+          return;
+        }
+        configParams = parsed as Record<string, unknown>;
+      } catch {
+        addToast("config.json is not valid JSON. Fix it before running a backtest.", "warning");
+        return;
+      }
+    }
+
     const parsedStartingEquity = Number.parseFloat((values.startingEquity ?? "").replace(/,/g, ""));
     const initialCapital = Number.isFinite(parsedStartingEquity) ? parsedStartingEquity : 0;
 
@@ -211,6 +242,7 @@ export default function StrategyBacktest() {
         start_date: values.startDate,
         end_date: values.endDate,
         initial_capital: initialCapital,
+        config_params: configParams,
       });
 
       const POLL_INTERVAL_MS = 2000;

--- a/frontend/app/routes/strategy/code.tsx
+++ b/frontend/app/routes/strategy/code.tsx
@@ -35,7 +35,6 @@ export default function StrategyCodeWorkspace() {
     lastBacktestParamValues,
   } = useStrategyWorkspace();
 
-  const DEFAULT_CONFIG = `{\n  "WINDOW": 21,\n  "STOP_LOSS": 0.05\n}`;
   const hasConfig = files.some((f) => f.path === "config.json" || f.path.endsWith("/config.json"));
   const [isAddingConfig, setIsAddingConfig] = useState(false);
 
@@ -43,7 +42,7 @@ export default function StrategyCodeWorkspace() {
     if (!strategy || isAddingConfig || hasConfig) return;
     setIsAddingConfig(true);
     try {
-      const file = { path: "config.json", language: "json", content: DEFAULT_CONFIG, isEntrypoint: false };
+      const file = { path: "config.json", language: "json", content: "", isEntrypoint: false };
       await uploadStrategyArtifacts(strategy.id, [file]);
       addFile(file);
       selectFile("config.json");

--- a/frontend/app/routes/strategy/code.tsx
+++ b/frontend/app/routes/strategy/code.tsx
@@ -1,6 +1,7 @@
 import Editor from "@monaco-editor/react";
 import { useEffect, useMemo, useState } from "react";
 import { getBacktestJob, submitBacktest } from "~/api/backtest";
+import { uploadStrategyArtifacts } from "~/api/strategyArtifacts";
 import { useStrategyWorkspace } from "./layout";
 
 function getFileKind(path: string) {
@@ -25,6 +26,7 @@ export default function StrategyCodeWorkspace() {
     selectedFilePath,
     selectFile,
     updateFileContent,
+    addFile,
     isDirty,
     isSaving,
     loadingFilePath,
@@ -32,6 +34,26 @@ export default function StrategyCodeWorkspace() {
     addToast,
     lastBacktestParamValues,
   } = useStrategyWorkspace();
+
+  const DEFAULT_CONFIG = `{\n  "WINDOW": 21,\n  "STOP_LOSS": 0.05\n}`;
+  const hasConfig = files.some((f) => f.path === "config.json" || f.path.endsWith("/config.json"));
+  const [isAddingConfig, setIsAddingConfig] = useState(false);
+
+  const handleAddConfig = async () => {
+    if (!strategy || isAddingConfig || hasConfig) return;
+    setIsAddingConfig(true);
+    try {
+      const file = { path: "config.json", language: "json", content: DEFAULT_CONFIG, isEntrypoint: false };
+      await uploadStrategyArtifacts(strategy.id, [file]);
+      addFile(file);
+      selectFile("config.json");
+      addToast("config.json created", "success");
+    } catch {
+      addToast("Failed to create config.json", "warning");
+    } finally {
+      setIsAddingConfig(false);
+    }
+  };
 
   const [editorReady, setEditorReady] = useState(false);
   const [isTypeChecking, setIsTypeChecking] = useState(false);
@@ -140,7 +162,7 @@ export default function StrategyCodeWorkspace() {
         <section className="flex min-w-0 flex-col">
           <div className="border-b border-white/10 bg-[#0a1220] px-4 pt-3">
             <div className="flex flex-wrap items-center justify-between gap-3">
-              <div className="flex min-w-0 flex-1 flex-wrap gap-2">
+              <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                 {sortedCodeFiles.length === 0 ? (
                   <div className="inline-flex items-center rounded-t-2xl border border-b-0 border-white/10 bg-[#101a2a] px-4 py-3 text-sm text-slate-400">
                     No files loaded
@@ -171,6 +193,17 @@ export default function StrategyCodeWorkspace() {
                       </button>
                     );
                   })
+                )}
+                {!hasConfig && (
+                  <button
+                    type="button"
+                    onClick={handleAddConfig}
+                    disabled={isAddingConfig}
+                    title="Add config.json"
+                    className="inline-flex items-center justify-center rounded-t-2xl border border-b-0 border-transparent bg-white/[0.03] px-3 py-3 text-slate-500 transition hover:bg-white/[0.06] hover:text-slate-200 disabled:opacity-40"
+                  >
+                    <span className="text-base leading-none">+</span>
+                  </button>
                 )}
               </div>
 

--- a/frontend/app/routes/strategy/layout.tsx
+++ b/frontend/app/routes/strategy/layout.tsx
@@ -48,6 +48,7 @@ export type StrategyWorkspaceContext = {
   isSavedBacktestRunsLoading: boolean;
   refreshSavedBacktestRuns: () => Promise<void>;
   addToast: (message: string, variant?: ToastVariant) => void;
+  addFile: (file: StrategyFile) => void;
   loadingFilePath: string | null;
   fileLoadError: string | null;
 };
@@ -232,6 +233,10 @@ export default function StrategyLayout() {
 
   const selectFile = useCallback((path: string) => {
     setSelectedFilePath(path);
+  }, []);
+
+  const addFile = useCallback((file: StrategyFile) => {
+    setFiles((prev) => [...prev, file]);
   }, []);
 
   const updateFileContent = useCallback(
@@ -460,6 +465,7 @@ export default function StrategyLayout() {
     isSavedBacktestRunsLoading,
     refreshSavedBacktestRuns,
     addToast,
+    addFile,
     loadingFilePath,
     fileLoadError,
   };


### PR DESCRIPTION
Previously, if users wanted to use parameters within their strategy, they'd have to hardcode them whenever used. This won't scale once simulations are introduced, so a config file was introduced as a place for parameters to live and be optimized. By default, new strategies should come with a config tab (once deployed), but if your pre-existing strategy doesn't, just click the + button on the tabs to create one. It'll come up with a basic scaffolding with a couple placeholder parameters. 