### PR TITLE
Feat/drawdown benchmark series

### DIFF
--- a/frontend/app/api/backtest.ts
+++ b/frontend/app/api/backtest.ts
@@ -32,11 +32,16 @@ export type Metrics = {
   sharpe: number;
   sortino: number;
   calmar?: number | null;
+  omega: number;
+  treynor?: number | null;
   psr: number;
 
   // return
   total_pct_return: number;
   annualized_return?: number | null;
+  best_day: number;
+  worst_day: number;
+  avg_daily_return: number;
 
   // risk
   ann_vol: number;
@@ -44,11 +49,29 @@ export type Metrics = {
   max_drawdown_duration: number;
   var_95: number;
   cvar_95: number;
+  skewness: number;
+  excess_kurtosis: number;
+  tail_ratio: number;
+  ulcer_index: number;
+  ulcer_performance_index?: number | null;
 
-  // benchmark
+  // benchmark-relative
   alpha: number;
   beta: number;
+  information_ratio?: number | null;
+  tracking_error?: number | null;
+
+  // trade analysis
   total_orders: number;
+  winning_trades: number;
+  losing_trades: number;
+  win_rate: number;
+  avg_win: number;
+  avg_loss: number;
+  largest_win: number;
+  largest_loss: number;
+  profit_factor?: number | null;
+  expectancy: number;
 };
 
 export type BacktestCandle = {

--- a/frontend/app/api/backtest.ts
+++ b/frontend/app/api/backtest.ts
@@ -82,6 +82,19 @@ export type BacktestCandle = {
   close: number;
 };
 
+export type DrawdownPoint = {
+  time: number;
+  drawdown: number;
+};
+
+export type BenchmarkCandle = {
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+};
+
 export type BacktestParameters = {
   name: string;
   starting_equity: number;
@@ -95,6 +108,8 @@ export type BacktestResponse = {
   metrics: Metrics;
   candles: BacktestCandle[];
   orders: BacktestOrder[];
+  drawdown_series: DrawdownPoint[];
+  benchmark_candles: BenchmarkCandle[];
 };
 
 export type BacktestRequest = {


### PR DESCRIPTION
Add DrawdownPoint and BenchmarkCandle models. New standalone functions
compute_drawdown_series() and compute_benchmark_candles() in metrics.py.
BacktestResponse now includes drawdown_series and benchmark_candles
arrays (default to empty lists for backwards compatibility).

Benchmark is SPY normalized to the strategy's starting capital.

Changes also made to backtester