### PR TITLE
Feat/#31 token refresh

### DIFF
--- a/aws/lambdas/auth-checker/main.py
+++ b/aws/lambdas/auth-checker/main.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 import urllib.request
 from functools import lru_cache
 from http.cookies import SimpleCookie
@@ -13,6 +14,7 @@ dynamo = boto3.resource("dynamodb")
 USERS_TABLE = dynamo.Table(os.environ["USERS_TABLE"])
 JWKS_BUCKET = os.environ["JWKS_BUCKET"]
 AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+AUTH_ACCESS_TTL_SECONDS = int(os.environ.get("AUTH_ACCESS_TTL_SECONDS", "900"))
 
 @lru_cache(maxsize=1)
 def _get_jwks() -> Dict[str, Any]:
@@ -98,6 +100,10 @@ def decode_netid(token: str) -> Optional[str]:
             options={"require": ["exp", "sub"]},
         )
     except jwt.PyJWTError:
+        return None
+
+    issued_at = payload.get("iat")
+    if not isinstance(issued_at, int) or int(time.time()) > issued_at + AUTH_ACCESS_TTL_SECONDS:
         return None
 
     netid = payload.get("sub")

--- a/aws/lambdas/auth-granter/main.py
+++ b/aws/lambdas/auth-granter/main.py
@@ -176,7 +176,11 @@ def handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
         if not token:
             return _json_response(401, {"message": "Unauthorized"})
 
-        netid = _decode_netid(token)
+        payload = _decode_token_payload(token)
+        if not payload:
+            return _json_response(401, {"message": "Unauthorized"})
+
+        netid = _netid_from_payload(payload)
         if not netid:
             return _json_response(401, {"message": "Unauthorized"})
 
@@ -194,6 +198,7 @@ def handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
                 "netid": netid,
                 "roles": [str(role) for role in roles],
                 "display_name": display_name,
+                "expires_at": payload["exp"],
             },
         )
 
@@ -215,12 +220,19 @@ def handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
         if not isinstance(roles, list):
             roles = [roles]
 
-        token = mint_jwt(netid, [str(role) for role in roles], payload["refresh_until"])
+        token, token_payload = mint_jwt_with_payload(netid, [str(role) for role in roles], payload["refresh_until"])
         return {
-            "statusCode": 204,
+            "statusCode": 200,
             "headers": {
                 "Set-Cookie": _build_auth_cookie(token),
+                "Content-Type": "application/json",
             },
+            "body": json.dumps(
+                {
+                    "expires_at": token_payload["exp"],
+                    "refresh_until": token_payload["refresh_until"],
+                }
+            ),
         }
 
     if route_key == "POST /auth/apply":
@@ -305,6 +317,15 @@ def validate_cas_ticket(ticket) -> str | None:
 
 def mint_jwt(netid: str, roles: Optional[List[str]] = None, refresh_until: Optional[int] = None):
     """Returns a JSON web token with the user's encoded netid and expiry"""
+    token, _payload = mint_jwt_with_payload(netid, roles, refresh_until)
+    return token
+
+
+def mint_jwt_with_payload(
+    netid: str,
+    roles: Optional[List[str]] = None,
+    refresh_until: Optional[int] = None,
+):
     now = int(time.time())
     roles = roles or []
     refresh_until = refresh_until or (now + AUTH_REFRESH_TTL_SECONDS)
@@ -319,7 +340,8 @@ def mint_jwt(netid: str, roles: Optional[List[str]] = None, refresh_until: Optio
     kid = _get_current_kid()
     if kid:
         headers = {"kid": kid}
-    return jwt.encode(payload, _get_private_key(), algorithm="RS256", headers=headers)
+    token = jwt.encode(payload, _get_private_key(), algorithm="RS256", headers=headers)
+    return token, payload
 
 # ----------------------------
 # Cookie/JWT helpers
@@ -335,6 +357,10 @@ def _decode_netid(token: str) -> Optional[str]:
     if not payload:
         return None
 
+    return _netid_from_payload(payload)
+
+
+def _netid_from_payload(payload: Dict[str, Any]) -> Optional[str]:
     netid = payload.get("sub")
     if not isinstance(netid, str):
         return None

--- a/aws/lambdas/auth-granter/main.py
+++ b/aws/lambdas/auth-granter/main.py
@@ -17,7 +17,13 @@ from boto3.dynamodb.conditions import Key
 import jwt
 
 APP_ENV = os.environ.get("APP_ENV", "prod").lower()
-AUTH_COOKIE_MAX_AGE_SECONDS = int(os.environ.get("AUTH_COOKIE_MAX_AGE_SECONDS", "86400"))
+AUTH_ACCESS_TTL_SECONDS = int(
+    os.environ.get(
+        "AUTH_ACCESS_TTL_SECONDS",
+        os.environ.get("AUTH_COOKIE_MAX_AGE_SECONDS", "900"),
+    )
+)
+AUTH_REFRESH_TTL_SECONDS = int(os.environ.get("AUTH_REFRESH_TTL_SECONDS", "86400"))
 
 CAS_BASE = "https://login.uconn.edu/cas"
 CAS_NS = {"cas": "http://www.yale.edu/tp/cas"}
@@ -118,7 +124,7 @@ def _build_auth_cookie(token: str) -> str:
     same_site = "Strict" if is_prod else "Lax"
     secure = "; Secure" if is_prod else ""
     domain = "; Domain=.uconnquant.com" if is_prod else ""
-    return f"hqg_auth_token={token}; Path=/; HttpOnly; SameSite={same_site}; Max-Age={AUTH_COOKIE_MAX_AGE_SECONDS}{domain}{secure}"
+    return f"hqg_auth_token={token}; Path=/; HttpOnly; SameSite={same_site}; Max-Age={AUTH_REFRESH_TTL_SECONDS}{domain}{secure}"
 
 def handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     """
@@ -126,6 +132,7 @@ def handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
     - GET /auth/login
     - GET /auth/callback
     - GET /auth/me
+    - POST /auth/refresh
     - POST /auth/apply
     - GET /auth/apply/check
     """
@@ -189,6 +196,32 @@ def handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
                 "display_name": display_name,
             },
         )
+
+    if route_key == "POST /auth/refresh":
+        token = _extract_token(event)
+        if not token:
+            return _json_response(401, {"message": "Unauthorized"})
+
+        payload = _decode_refresh_payload(token)
+        if not payload:
+            return _json_response(401, {"message": "Unauthorized"})
+
+        netid = payload["sub"].strip()
+        user = _load_user(netid)
+        if not user or user.get("is_banned", False):
+            return _json_response(403, {"message": "Forbidden"})
+
+        roles = user.get("roles") or []
+        if not isinstance(roles, list):
+            roles = [roles]
+
+        token = mint_jwt(netid, [str(role) for role in roles], payload["refresh_until"])
+        return {
+            "statusCode": 204,
+            "headers": {
+                "Set-Cookie": _build_auth_cookie(token),
+            },
+        }
 
     if route_key == "POST /auth/apply":
         token = _extract_token(event)
@@ -270,14 +303,16 @@ def validate_cas_ticket(ticket) -> str | None:
 
     return success.findtext("cas:user", default="", namespaces=CAS_NS) or None
 
-def mint_jwt(netid: str, roles: Optional[List[str]] = None):
+def mint_jwt(netid: str, roles: Optional[List[str]] = None, refresh_until: Optional[int] = None):
     """Returns a JSON web token with the user's encoded netid and expiry"""
     now = int(time.time())
     roles = roles or []
+    refresh_until = refresh_until or (now + AUTH_REFRESH_TTL_SECONDS)
     payload = {
         "sub": netid, # subject
         "iat": now,
-        "exp": now + AUTH_COOKIE_MAX_AGE_SECONDS,
+        "exp": min(now + AUTH_ACCESS_TTL_SECONDS, refresh_until),
+        "refresh_until": refresh_until,
         "roles": roles,
     }
     headers: Optional[Dict[str, str]] = None
@@ -296,6 +331,36 @@ def _extract_token(event: Dict[str, Any]) -> Optional[str]:
 
 
 def _decode_netid(token: str) -> Optional[str]:
+    payload = _decode_token_payload(token)
+    if not payload:
+        return None
+
+    netid = payload.get("sub")
+    if not isinstance(netid, str):
+        return None
+
+    netid = netid.strip()
+    return netid or None
+
+
+def _decode_refresh_payload(token: str) -> Optional[Dict[str, Any]]:
+    payload = _decode_token_payload(token, verify_exp=False)
+    if not payload:
+        return None
+
+    netid = payload.get("sub")
+    refresh_until = payload.get("refresh_until")
+    if not isinstance(netid, str) or not netid.strip():
+        return None
+    if not isinstance(refresh_until, int):
+        return None
+    if int(time.time()) > refresh_until:
+        return None
+
+    return {"sub": netid, "refresh_until": refresh_until}
+
+
+def _decode_token_payload(token: str, verify_exp: bool = True) -> Optional[Dict[str, Any]]:
     public_key = _get_public_key(token)
     if not public_key:
         return None
@@ -305,17 +370,19 @@ def _decode_netid(token: str) -> Optional[str]:
             token,
             public_key,
             algorithms=["RS256"],
-            options={"require": ["exp", "sub"]},
+            options={
+                "verify_exp": verify_exp,
+                "require": ["exp", "sub"],
+            },
         )
     except jwt.PyJWTError:
         return None
 
-    netid = payload.get("sub")
-    if not isinstance(netid, str):
+    issued_at = payload.get("iat")
+    if verify_exp and (not isinstance(issued_at, int) or int(time.time()) > issued_at + AUTH_ACCESS_TTL_SECONDS):
         return None
 
-    netid = netid.strip()
-    return netid or None
+    return payload
 
 
 def _user_allowed(netid: str) -> bool:

--- a/aws/lambdas/auth-granter/main.py
+++ b/aws/lambdas/auth-granter/main.py
@@ -199,6 +199,7 @@ def handler(event: Dict[str, Any], _context: Any) -> Dict[str, Any]:
                 "roles": [str(role) for role in roles],
                 "display_name": display_name,
                 "expires_at": payload["exp"],
+                "refresh_until": payload.get("refresh_until"),
             },
         )
 

--- a/frontend/app/api/backtest.ts
+++ b/frontend/app/api/backtest.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { attachAuthRefreshInterceptor } from "./core";
 import { backtesterApiOrigin, isProd } from "./runtime";
 
 
@@ -11,6 +12,8 @@ export const backtesterApi = axios.create({
   baseURL: backtesterApiBaseUrl,
   withCredentials: true,
 });
+
+attachAuthRefreshInterceptor(backtesterApi);
 
 export type BacktestOrder = {
   id: string;

--- a/frontend/app/api/core.ts
+++ b/frontend/app/api/core.ts
@@ -14,6 +14,8 @@ export const coreApi = axios.create({
   withCredentials: true,
 });
 
+export const authLoginUrl = `${coreApiBaseUrl}/auth/login`;
+
 let refreshPromise: Promise<void> | null = null;
 let authSessionExpiresAtMs: number | null = null;
 

--- a/frontend/app/api/core.ts
+++ b/frontend/app/api/core.ts
@@ -5,18 +5,38 @@ type AuthRetryConfig = InternalAxiosRequestConfig & {
   _authRetry?: boolean;
 };
 
+type RefreshResponse = {
+  expires_at?: number;
+};
+
 export const coreApi = axios.create({
   baseURL: coreApiBaseUrl,
   withCredentials: true,
 });
 
 let refreshPromise: Promise<void> | null = null;
+let authSessionExpiresAtMs: number | null = null;
+
+export function noteAuthSessionExpiresAt(expiresAtSeconds?: number) {
+  if (typeof expiresAtSeconds !== "number" || !Number.isFinite(expiresAtSeconds)) {
+    authSessionExpiresAtMs = null;
+    return;
+  }
+
+  authSessionExpiresAtMs = expiresAtSeconds * 1000;
+}
+
+export function shouldRefreshAuthSession(bufferMs: number): boolean {
+  return authSessionExpiresAtMs === null || authSessionExpiresAtMs - Date.now() <= bufferMs;
+}
 
 export function refreshAuthSession(): Promise<void> {
   if (!refreshPromise) {
     refreshPromise = coreApi
-      .post("/auth/refresh")
-      .then(() => undefined)
+      .post<RefreshResponse>("/auth/refresh")
+      .then((response) => {
+        noteAuthSessionExpiresAt(response.data?.expires_at);
+      })
       .finally(() => {
         refreshPromise = null;
       });

--- a/frontend/app/api/core.ts
+++ b/frontend/app/api/core.ts
@@ -1,7 +1,52 @@
-import axios from "axios";
+import axios, { type AxiosError, type AxiosInstance, type InternalAxiosRequestConfig } from "axios";
 import { coreApiBaseUrl } from "./runtime";
+
+type AuthRetryConfig = InternalAxiosRequestConfig & {
+  _authRetry?: boolean;
+};
 
 export const coreApi = axios.create({
   baseURL: coreApiBaseUrl,
   withCredentials: true,
 });
+
+let refreshPromise: Promise<void> | null = null;
+
+export function refreshAuthSession(): Promise<void> {
+  if (!refreshPromise) {
+    refreshPromise = coreApi
+      .post("/auth/refresh")
+      .then(() => undefined)
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
+}
+
+export function attachAuthRefreshInterceptor(api: AxiosInstance) {
+  api.interceptors.response.use(
+    (response) => response,
+    async (error: AxiosError) => {
+      const status = error.response?.status;
+      const config = error.config as AuthRetryConfig | undefined;
+
+      if (
+        status !== 401 ||
+        !config ||
+        config._authRetry ||
+        config.url?.includes("/auth/refresh") ||
+        config.url?.includes("/auth/login")
+      ) {
+        return Promise.reject(error);
+      }
+
+      config._authRetry = true;
+      await refreshAuthSession();
+      return api(config);
+    }
+  );
+}
+
+attachAuthRefreshInterceptor(coreApi);

--- a/frontend/app/api/portfolio.ts
+++ b/frontend/app/api/portfolio.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { attachAuthRefreshInterceptor } from "./core";
 import { engineApiOrigin, isProd } from "./runtime";
 
 const engineApiBaseUrl = isProd ? engineApiOrigin : engineApiOrigin;
@@ -7,6 +8,8 @@ export const engineApi = axios.create({
   baseURL: engineApiBaseUrl,
   withCredentials: true,
 });
+
+attachAuthRefreshInterceptor(engineApi);
 
 export type Timeframe = "3M" | "6M" | "YTD" | null;
 

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -12,6 +12,7 @@ import {
 import type { Route } from "./+types/root";
 import "./app.css";
 import {
+  authLoginUrl,
   coreApi,
   noteAuthSessionExpiresAt,
   refreshAuthSession,
@@ -140,8 +141,20 @@ function AppContent() {
           roles?: string[];
           display_name?: string;
           expires_at?: number;
+          refresh_until?: number;
         };
         noteAuthSessionExpiresAt(data.expires_at);
+
+        const minRefreshWindowMs = 8 * 60 * 60 * 1000;
+        const refreshUntilMs =
+          typeof data.refresh_until === "number" && Number.isFinite(data.refresh_until)
+            ? data.refresh_until * 1000
+            : null;
+        if (refreshUntilMs === null || refreshUntilMs - Date.now() < minRefreshWindowMs) {
+          window.location.assign(authLoginUrl);
+          return;
+        }
+
         if (!isCancelled) {
           setUser(
             data?.netid

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -11,7 +11,7 @@ import {
 
 import type { Route } from "./+types/root";
 import "./app.css";
-import { coreApi } from "./api/core";
+import { coreApi, refreshAuthSession } from "./api/core";
 import axios from "axios";
 import { UserProvider, useUser } from "./context/UserConext";
 
@@ -88,6 +88,32 @@ function AppContent() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const { setUser } = useUser();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const refreshQuietly = () => {
+      refreshAuthSession().catch(() => {
+        // Let the next user-initiated request or route check handle login UX.
+      });
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        refreshQuietly();
+      }
+    };
+
+    const intervalId = window.setInterval(refreshQuietly, 10 * 60 * 1000);
+    window.addEventListener("focus", refreshQuietly);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.clearInterval(intervalId);
+      window.removeEventListener("focus", refreshQuietly);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, []);
 
   useEffect(() => {
     if (typeof window === "undefined") return;

--- a/frontend/app/root.tsx
+++ b/frontend/app/root.tsx
@@ -11,7 +11,12 @@ import {
 
 import type { Route } from "./+types/root";
 import "./app.css";
-import { coreApi, refreshAuthSession } from "./api/core";
+import {
+  coreApi,
+  noteAuthSessionExpiresAt,
+  refreshAuthSession,
+  shouldRefreshAuthSession,
+} from "./api/core";
 import axios from "axios";
 import { UserProvider, useUser } from "./context/UserConext";
 
@@ -92,25 +97,33 @@ function AppContent() {
   useEffect(() => {
     if (typeof window === "undefined") return;
 
+    const refreshBufferMs = 5 * 60 * 1000;
+
     const refreshQuietly = () => {
       refreshAuthSession().catch(() => {
         // Let the next user-initiated request or route check handle login UX.
       });
     };
 
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
+    const refreshIfNearExpiry = () => {
+      if (shouldRefreshAuthSession(refreshBufferMs)) {
         refreshQuietly();
       }
     };
 
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        refreshIfNearExpiry();
+      }
+    };
+
     const intervalId = window.setInterval(refreshQuietly, 10 * 60 * 1000);
-    window.addEventListener("focus", refreshQuietly);
+    window.addEventListener("focus", refreshIfNearExpiry);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
       window.clearInterval(intervalId);
-      window.removeEventListener("focus", refreshQuietly);
+      window.removeEventListener("focus", refreshIfNearExpiry);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, []);
@@ -122,7 +135,13 @@ function AppContent() {
     const run = async () => {
       try {
         const response = await coreApi.get("/auth/me");
-        const data = response.data as { netid?: string; roles?: string[]; display_name?: string };
+        const data = response.data as {
+          netid?: string;
+          roles?: string[];
+          display_name?: string;
+          expires_at?: number;
+        };
+        noteAuthSessionExpiresAt(data.expires_at);
         if (!isCancelled) {
           setUser(
             data?.netid

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1279,6 +1279,8 @@ resource "aws_lambda_function" "auth_granter" {
       JWT_PRIVATE_KEY_PARAMETER      = aws_ssm_parameter.jwt_private_key.name
       JWKS_BUCKET                    = aws_s3_bucket.jwks.bucket
       APP_ENV                        = var.env
+      AUTH_ACCESS_TTL_SECONDS        = "900"
+      AUTH_REFRESH_TTL_SECONDS       = "86400"
       USERS_TABLE                    = aws_dynamodb_table.users.name
       USER_ACCESS_APPLICATIONS_TABLE = aws_dynamodb_table.user_access_applications.name
     }
@@ -1303,8 +1305,9 @@ resource "aws_lambda_function" "auth_checker" {
 
   environment {
     variables = {
-      USERS_TABLE = aws_dynamodb_table.users.name
-      JWKS_BUCKET = aws_s3_bucket.jwks.bucket
+      USERS_TABLE             = aws_dynamodb_table.users.name
+      JWKS_BUCKET             = aws_s3_bucket.jwks.bucket
+      AUTH_ACCESS_TTL_SECONDS = "900"
     }
   }
 
@@ -1658,6 +1661,12 @@ resource "aws_apigatewayv2_route" "auth_callback" {
 resource "aws_apigatewayv2_route" "auth_me" {
   api_id    = aws_apigatewayv2_api.api.id
   route_key = "GET /auth/me"
+  target    = "integrations/${aws_apigatewayv2_integration.auth_granter.id}"
+}
+
+resource "aws_apigatewayv2_route" "auth_refresh" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "POST /auth/refresh"
   target    = "integrations/${aws_apigatewayv2_integration.auth_granter.id}"
 }
 


### PR DESCRIPTION
## Summary

Adds refresh support for the existing HTTP-only `hqg_auth_token` cookie while keeping protected-service token validity short.

Auth now uses a 15-minute access window and a 24-hour fixed refresh window. The frontend can silently refresh the cookie through a new `/auth/refresh` endpoint, retry failed API calls once after refreshing, and proactively send users through CAS on app boot if their refresh window is close to expiring.

## Changes

- Split auth lifetime into:
  - 15-minute access validity via `AUTH_ACCESS_TTL_SECONDS=900`
  - 24-hour refresh/cookie window via `AUTH_REFRESH_TTL_SECONDS=86400`
- Added `refresh_until` to minted JWTs as a fixed absolute refresh deadline.
- Added `POST /auth/refresh` to renew the existing HTTP-only auth cookie without adding a second token.
- Updated `/auth/me` to return `expires_at` and `refresh_until` so the frontend can make refresh decisions without reading the HTTP-only cookie.
- Updated `auth-checker` to reject tokens older than the access TTL, even if an older token has a longer `exp`.
- Wired the new refresh route and TTL environment variables in Terraform.
- Added shared frontend refresh logic in `coreApi`.
- Added Axios `401 -> refresh once -> retry original request` behavior.
- Attached refresh retry behavior to core, backtester, and engine API clients.
- Added background refresh every 10 minutes while the app is open.
- Added focus/visibility refresh only when the cached access token expiry is unknown or within 5 minutes.
- Added app-boot re-login behavior when the refresh window has less than 8 hours remaining.

## Current Auth Flow

### Case 1: New User Logs In Normally

1. User visits the app.
2. `root.tsx` calls `GET /auth/me`.
3. If no valid auth cookie exists, the frontend navigates to `/login`.
4. `/login` links to `/auth/login`.
5. `/auth/login` redirects the user to UConn CAS.
6. CAS returns to `/auth/callback`.
7. `auth-granter` validates the CAS ticket.
8. `auth-granter` mints a JWT with:
   - `exp = now + 15 minutes`
   - `refresh_until = now + 24 hours`
9. The JWT is set in the existing HTTP-only `hqg_auth_token` cookie.
10. User enters the app.

### Case 2: User Loads App With A Valid Session

1. `root.tsx` calls `GET /auth/me`.
2. `auth-granter` validates the cookie using normal JWT expiry rules.
3. `/auth/me` returns:
   - user identity
   - roles
   - display name
   - `expires_at`
   - `refresh_until`
4. Frontend records `expires_at` locally.
5. If `refresh_until` has at least 8 hours remaining, the app renders normally.

### Case 3: User Loads App Near Refresh Expiry

1. `root.tsx` calls `GET /auth/me`.
2. `/auth/me` succeeds but returns a `refresh_until` less than 8 hours away.
3. The frontend redirects directly to `/auth/login`.
4. CAS re-authentication mints a brand-new token with a fresh 24-hour refresh window.
5. This only happens on app boot, not while the user is already working.

### Case 4: Active User Keeps The App Open

1. The frontend runs a quiet refresh every 10 minutes.
2. `POST /auth/refresh` reads the existing cookie.
3. It verifies the JWT signature while ignoring the normal 15-minute `exp`.
4. It checks `refresh_until`.
5. If still within the 24-hour refresh window, it reloads the user and roles from DynamoDB.
6. It mints a new JWT with a fresh 15-minute `exp`.
7. It preserves the original `refresh_until`.
8. It sets the refreshed cookie and returns the new expiry metadata.

### Case 5: User Comes Back To A Tab

1. Browser focus or visibility-change events fire.
2. The frontend checks the cached `expires_at`.
3. If the token has more than 5 minutes left, nothing happens.
4. If the token is unknown or has less than 5 minutes left, the frontend quietly calls `/auth/refresh`.
5. Refresh failure is swallowed here so the app does not immediately wipe in-progress UI state.

### Case 6: API Call Hits An Expired 15-Minute Token

1. A request to core, backtester, or engine gets `401`.
2. The Axios interceptor calls `POST /auth/refresh`.
3. If refresh succeeds, the original request is retried once.
4. If refresh fails, the original request rejects normally and existing app error handling takes over.
5. Concurrent `401`s share one refresh request through a shared `refreshPromise`.

### Case 7: Refresh Window Has Expired

1. `/auth/refresh` verifies the token signature but sees `refresh_until` is in the past.
2. Refresh fails with `401`.
3. The frontend cannot renew the session silently.
4. User must go back through `/auth/login` and CAS to get a new 24-hour refresh window.

### Case 8: User Is Forbidden Or Banned

1. `/auth/me` or `/auth/refresh` loads the user from DynamoDB.
2. If the user is missing or banned, the backend returns `403`.
3. On app boot, the frontend sends `403` users to `/apply`.
4. Protected service requests continue to rely on `auth-checker` and route-level authorization context.

## Notes

- This keeps a single HTTP-only cookie. No separate refresh token was added.
- `refresh_until` is intentionally not extended during refresh. It is a fixed absolute session cap.
- Existing old cookies may require a fresh CAS login because they may not have the new `refresh_until` claim.
- API Gateway authorizer caching still has its configured TTL, so protected-service rejection may not be perfectly exact to the second.
